### PR TITLE
Centralize assets and theme

### DIFF
--- a/src/constants/appConfig.tsx
+++ b/src/constants/appConfig.tsx
@@ -1,11 +1,2 @@
 export const APP_NAME = 'Salamtak';
-import logo from '../assets/logo.jpg';
-
-export const LOGO_URL = logo;
 export const BASE_URL = 'http://localhost:8080';
-// src/constants/theme.ts
-export const COLORS = {
-    primary: '#2563eb',   // Tailwind's blue-600
-    secondary: '#1e293b', // slate-800
-    background: '#f8fafc' // slate-50
-};

--- a/src/constants/assets.ts
+++ b/src/constants/assets.ts
@@ -1,0 +1,7 @@
+import logo from '../assets/logo.jpg';
+import heroImage from '../assets/doctor2.png';
+import signupBg from '../assets/signup-bg.jpg';
+
+export const LOGO_URL = logo;
+export const HERO_IMAGE = heroImage;
+export const SIGNUP_BG = signupBg;

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -1,0 +1,5 @@
+export const COLORS = {
+    primary: '#2563eb',   // Tailwind's blue-600
+    secondary: '#1e293b', // slate-800
+    background: '#f8fafc' // slate-50
+};

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -1,10 +1,10 @@
 // src/pages/AuthPage.tsx
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { APP_NAME, LOGO_URL } from '../constants/appConfig';
+import { APP_NAME } from '../constants/appConfig';
+import { LOGO_URL, SIGNUP_BG } from '../constants/assets';
 import LoginForm from '../components/LoginForm';
 import SignupForm from '../components/SignupForm';
-import signupBg from '../assets/signup-bg.jpg';
 
 const AuthPage: React.FC = () => {
     const [mode, setMode] = useState<'login' | 'signup'>('login');
@@ -34,7 +34,7 @@ const AuthPage: React.FC = () => {
             </div>
 
             <div className="hidden md:block">
-                <img src={signupBg} alt="Signup" className="object-cover w-full h-full" />
+                <img src={SIGNUP_BG} alt="Signup" className="object-cover w-full h-full" />
             </div>
         </div>
     );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,10 +1,9 @@
 // src/pages/HomePage.tsx
 import React from 'react';
-import { COLORS } from '../constants/appConfig';
+import { COLORS } from '../constants/theme';
+import { LOGO_URL, HERO_IMAGE } from '../constants/assets';
 import { useAuth } from '../contexts/ContextsAuth';
 import { useTranslation } from 'react-i18next';
-import logo from '../assets/logo.jpg'; // adjust path if needed
-import heroImage from '../assets/doctor2.png'; // right-side doctor image
 
 const HomePage: React.FC = () => {
     const { user } = useAuth();
@@ -19,7 +18,7 @@ const HomePage: React.FC = () => {
         <div className="min-h-screen bg-white">
             {/* Navbar */}
             <nav className="flex justify-between items-center px-6 py-4 text-white" style={{ backgroundColor: COLORS.primary }}>
-                <img src={logo} alt="Logo" className="h-8" />
+                <img src={LOGO_URL} alt="Logo" className="h-8" />
                 <div className="flex items-center space-x-6 text-sm font-medium">
                     <button className="bg-white text-blue-700 px-3 py-1 rounded-full">{t('provider')}</button>
                     <a href="#" className="hover:underline">{t('help')}</a>
@@ -59,7 +58,7 @@ const HomePage: React.FC = () => {
 
                 {/* Floating Image */}
                 <img
-                    src={heroImage}
+                    src={HERO_IMAGE}
                     alt="Doctor"
                     className="absolute bottom-0 right-0 h-[500px] object-contain z-0"
                 />


### PR DESCRIPTION
## Summary
- separate app config from theme and assets
- create `constants/theme.ts` and `constants/assets.ts`
- update imports in `AuthPage` and `HomePage`

## Testing
- `npm run lint`
- `npm run build` *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684f406cd7f08331887d9e2c5e4250f6