### PR TITLE
Add patient appointments page and navbar link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import AuthPage from './pages/AuthPage';
 import { useTranslation } from 'react-i18next';
 import DoctorsPage from './pages/DoctorsPage';
 import AppointmentBookingPage from './pages/AppointmentBookingPage';
+import AppointmentsPage from './pages/AppointmentsPage';
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 
 const App: React.FC = () => {
@@ -29,6 +30,7 @@ const App: React.FC = () => {
             <Route path="/login" element={<AuthPage />} />
             <Route path="/book" element={<DoctorsPage />} />
             <Route path="/book/:doctorId" element={<AppointmentBookingPage />} />
+            <Route path="/my-appointments" element={<AppointmentsPage />} />
         </Routes>
     </Router>
     );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -34,6 +34,9 @@ const Navbar: React.FC = () => {
                         <a href="/book" className="hover:underline">
                             {t('book')}
                         </a>
+                        <a href="/my-appointments" className="hover:underline">
+                            {t('appointments')}
+                        </a>
                         <div className="w-8 h-8 rounded-full bg-white text-blue-700 flex items-center justify-center font-bold">
                             {user.username.charAt(0).toUpperCase()}
                         </div>

--- a/src/constants/apiConfig.ts
+++ b/src/constants/apiConfig.ts
@@ -5,4 +5,8 @@ export const API_ENDPOINTS = {
   doctorAppointments: (id: number | string) => `/doctors/${id}/appointments`,
   doctor: (id: number | string) => `/doctors/${id}`,
   availableSlots: (id: number | string) => `/appointments/doctor/${id}/available-slots`,
+  patientAppointments: (
+    id: number | string,
+    patientId: number | string,
+  ) => `/appointments/${id}/patient/${patientId}/appointments`,
 };

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -4,6 +4,7 @@
   "locationPlaceholder": "أين؟",
   "login": "تسجيل الدخول",
   "appointments": "مواعيدي",
+  "noAppointments": "لا توجد مواعيد",
   "profile": "الملف الشخصي",
   "book": "احجز موعدًا",
   "provider": "هل أنت مقدم خدمة؟",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -4,6 +4,7 @@
   "locationPlaceholder": "Where?",
   "login": "Login",
   "appointments": "My Appointments",
+  "noAppointments": "No appointments found.",
   "profile": "Profile",
   "book": "Book Appointment",
   "provider": "Are you a provider?",

--- a/src/pages/AppointmentsPage.tsx
+++ b/src/pages/AppointmentsPage.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import Navbar from '../components/Navbar';
+import { useAuth } from '../contexts/ContextsAuth';
+import api from '../services/api';
+import { API_ENDPOINTS } from '../constants/apiConfig';
+import { useTranslation } from 'react-i18next';
+
+interface Appointment {
+    id: number | string;
+    dateTime: string;
+    doctorName?: string;
+}
+
+const AppointmentsPage: React.FC = () => {
+    const { accessToken, user } = useAuth();
+    const { t } = useTranslation();
+    const [appointments, setAppointments] = useState<Appointment[]>([]);
+
+    useEffect(() => {
+        if (!user) return;
+        api
+            .get(API_ENDPOINTS.patientAppointments(user.id, user.id), {
+                headers: { Authorization: `Bearer ${accessToken}` },
+            })
+            .then((res) => setAppointments(res.data))
+            .catch((err) => console.error(err));
+    }, [accessToken, user]);
+
+    return (
+        <div className="min-h-screen bg-white">
+            <Navbar />
+            <div className="p-6">
+                <h2 className="text-xl font-semibold mb-4">{t('appointments')}</h2>
+                {appointments.length === 0 ? (
+                    <p>{t('noAppointments')}</p>
+                ) : (
+                    <ul className="space-y-2">
+                        {appointments.map((appt) => (
+                            <li key={appt.id} className="bg-gray-100 p-4 rounded">
+                                <p>{appt.doctorName}</p>
+                                <p>{appt.dateTime}</p>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default AppointmentsPage;


### PR DESCRIPTION
## Summary
- add endpoints for patient appointments
- implement `AppointmentsPage` for viewing user's appointments
- link My Appointments page in navbar
- wire up route for My Appointments
- provide translations for empty appointments message

## Testing
- `npm run lint`
- `npm run build` *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684f6601b39883318155c3b4bb7a3e75