### PR TITLE
Improve auth flow and navbar navigation

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -22,16 +22,18 @@ const LoginForm: React.FC<Props> = ({ onSwitch }) => {
 
     const handleLogin = async (e: React.FormEvent) => {
         e.preventDefault();
-        const res = await fetch(`${BASE_URL}/auth/login`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(formData),
-        });
-        if (res.ok) {
+        try {
+            const res = await fetch(`${BASE_URL}/auth/login`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(formData),
+            });
+
+            if (!res.ok) throw new Error('Login failed');
             const data = await res.json();
             login(data);
             navigate('/');
-        } else {
+        } catch {
             alert('Login failed');
         }
     };

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../contexts/ContextsAuth';
 import { COLORS } from '../constants/theme';
 import { logo } from '../constants/assets';
@@ -17,7 +18,9 @@ const Navbar: React.FC = () => {
             className="flex justify-between items-center px-6 py-4 text-white"
             style={{ backgroundColor: COLORS.primary }}
         >
-            <img src={logo} alt="Logo" className="h-8" />
+            <Link to="/">
+                <img src={logo} alt="Logo" className="h-8" />
+            </Link>
             <div className="flex items-center gap-6 text-sm font-medium">
                 <button className="bg-white text-blue-700 px-3 py-1 rounded-full transform transition-transform duration-300 hover:scale-105 will-change-transform"
                 style={{ color: COLORS.primary }}>
@@ -31,22 +34,22 @@ const Navbar: React.FC = () => {
                 </button>
                 {user ? (
                     <>
-                        <a href="/book" className="hover:underline">
+                        <Link to="/book" className="hover:underline">
                             {t('book')}
-                        </a>
-                        <a href="/my-appointments" className="hover:underline">
+                        </Link>
+                        <Link to="/my-appointments" className="hover:underline">
                             {t('appointments')}
-                        </a>
-                        <a href="/profile">
+                        </Link>
+                        <Link to="/profile">
                             <div className="w-8 h-8 rounded-full bg-white text-blue-700 flex items-center justify-center font-bold">
                                 {user.username.charAt(0).toUpperCase()}
                             </div>
-                        </a>
+                        </Link>
                     </>
                 ) : (
-                    <a href="/login" className="hover:underline">
+                    <Link to="/login" className="hover:underline">
                         {t('login')}
-                    </a>
+                    </Link>
                 )}
             </div>
         </nav>

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -53,13 +53,20 @@ const SignupForm: React.FC<Props> = ({ onSwitch }) => {
             role: 'PATIENT',
         };
 
-        await fetch(`${BASE_URL}/auth/register`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload),
-        });
+        try {
+            const res = await fetch(`${BASE_URL}/auth/register`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            });
 
-        alert('Account created!');
+            if (!res.ok) throw new Error('Signup failed');
+
+            alert('Account created!');
+            onSwitch();
+        } catch {
+            alert('Signup failed');
+        }
     };
 
     return (


### PR DESCRIPTION
## Summary
- make navbar logo link back to home and use React Router links
- add error handling to login form
- redirect to login mode after successful signup

## Testing
- `npm run lint`
- `npm run build` *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684f775a40c483319e1870787b6c84f2