### PR TITLE
Implement OTP verification page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import AppointmentsPage from './pages/AppointmentsPage';
 import ProfilePage from './pages/ProfilePage';
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import DrugPage from "./pages/DrugPage";
+import VerifyOtpPage from './pages/VerifyOtpPage';
 
 const App: React.FC = () => {
     const { accessToken, refreshToken, login, logout } = useAuth();
@@ -37,6 +38,7 @@ const App: React.FC = () => {
             <Route path="/my-appointments" element={<AppointmentsPage />} />
             <Route path="/profile" element={<ProfilePage />} />
             <Route path="/drugs" element={<DrugPage />} />
+            <Route path="/verify-otp" element={<VerifyOtpPage />} />
         </Routes>
     </Router>
     );

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import LabeledInput from './LabeledInput';
 import Button from './Button';
 import { BASE_URL } from "../constants/apiConfig";
+import { useNavigate } from 'react-router-dom';
 
 type Props = {
     onSwitch: () => void;
@@ -10,6 +11,7 @@ type Props = {
 
 const SignupForm: React.FC<Props> = ({ onSwitch }) => {
     const { t } = useTranslation();
+    const navigate = useNavigate();
     const [formData, setFormData] = useState({
         username: '',
         password: '',
@@ -63,7 +65,9 @@ const SignupForm: React.FC<Props> = ({ onSwitch }) => {
             if (!res.ok) throw new Error('Signup failed');
 
             alert('Account created!');
-            onSwitch();
+            navigate('/verify-otp', {
+                state: { username: formData.username, email: formData.email },
+            });
         } catch {
             alert('Signup failed');
         }

--- a/src/pages/VerifyOtpPage.tsx
+++ b/src/pages/VerifyOtpPage.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import Navbar from '../components/Navbar';
+import LabeledInput from '../components/LabeledInput';
+import Button from '../components/Button';
+import { BASE_URL } from '../constants/apiConfig';
+
+const VerifyOtpPage: React.FC = () => {
+    const location = useLocation();
+    const navigate = useNavigate();
+    const { username, email } = (location.state || {}) as { username: string; email: string };
+    const [otp, setOtp] = useState('');
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        try {
+            const res = await fetch(`${BASE_URL}/auth/verfiy-otp`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, otp }),
+            });
+
+            if (!res.ok) throw new Error('Verification failed');
+
+            alert('Account verified!');
+            navigate('/login');
+        } catch {
+            alert('Verification failed');
+        }
+    };
+
+    return (
+        <div className="min-h-screen bg-white">
+            <Navbar />
+            <div className="flex items-center justify-center h-[calc(100vh-4rem)]">
+                <form onSubmit={handleSubmit} className="space-y-4 text-center">
+                    {email && (
+                        <p className="text-sm">We sent a code to {email}</p>
+                    )}
+                    <LabeledInput
+                        label="OTP"
+                        name="otp"
+                        value={otp}
+                        onChange={(e) => setOtp(e.target.value)}
+                        inputClassName="py-1.5 text-sm text-center"
+                    />
+                    <Button type="submit" className="w-full">
+                        Verify
+                    </Button>
+                </form>
+            </div>
+        </div>
+    );
+};
+
+export default VerifyOtpPage;


### PR DESCRIPTION
## Summary
- add VerifyOtpPage for entering OTP code
- navigate to OTP page after successful sign up
- register VerifyOtpPage route

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685595c4d7bc8331916883755c186762