### PR TITLE
Implement dynamic doctor dashboard

### DIFF
--- a/src/components/Doctor/DoctorAppointmentCard.tsx
+++ b/src/components/Doctor/DoctorAppointmentCard.tsx
@@ -25,20 +25,20 @@ interface Props {
 const DoctorAppointmentCard: React.FC<Props> = ({ appointment, onConfirm, onReschedule }) => {
     const { t } = useTranslation();
 
-    const date = dayjs(appointment.startTime).format('YYYY-MM-DD');
-    const time = dayjs(appointment.startTime).format('HH:mm');
+    const date = dayjs(appointment.startTime).format('DD MMM YY');
+    const time = dayjs(appointment.startTime).format('h:mm A');
 
     return (
-        <div className="bg-white shadow-md rounded-lg p-4 transition-transform transform hover:scale-105 hover:shadow-lg">
-            <h3 className="text-lg font-bold text-blue-700 mb-2">{t('appointment')}</h3>
+        <div className="flex flex-col md:flex-row md:items-center justify-between p-4 hover:bg-gray-50 transition border-b last:border-0">
+            <div className="flex flex-wrap items-center gap-6 text-sm">
+                <span className="w-24">{date}</span>
+                <span className="w-20">{time}</span>
+                <span className="w-24">{appointment.reason || 'FUP'}</span>
+                <span className="w-36">{appointment.patientId}</span>
+                <span className="w-24 text-gray-500">{appointment.status}</span>
+            </div>
 
-            <p className="text-sm"><strong>{t('date')}:</strong> {date}</p>
-            <p className="text-sm"><strong>{t('time')}:</strong> {time}</p>
-            <p className="text-sm"><strong>{t('reason')}:</strong> {appointment.reason || '—'}</p>
-            <p className="text-sm"><strong>{t('notes')}:</strong> {appointment.notes || '—'}</p>
-            <p className="text-sm"><strong>{t('status')}:</strong> {t(appointment.status.toLowerCase())}</p>
-
-            <div className="mt-4 flex gap-2">
+            <div className="mt-4 md:mt-0 flex gap-2">
                 <button
                     onClick={() => onConfirm(appointment.id)}
                     className="bg-blue-600 text-white px-4 py-1 rounded text-sm hover:bg-blue-700"
@@ -49,7 +49,7 @@ const DoctorAppointmentCard: React.FC<Props> = ({ appointment, onConfirm, onResc
                     onClick={() => onReschedule?.(appointment.id)}
                     className="bg-gray-600 text-white px-4 py-1 rounded text-sm hover:bg-gray-700"
                 >
-                    {t('reschedule')}
+                    {t('checkIn')}
                 </button>
             </div>
         </div>

--- a/src/components/Doctor/DoctorAppointments.tsx
+++ b/src/components/Doctor/DoctorAppointments.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAuth } from '../../contexts/ContextsAuth';
 import { useTranslation } from 'react-i18next';
 import api from '../../services/api';
-import DoctorAppointmentCard from "./DoctorAppointementCard";
+import DoctorAppointmentCard from './DoctorAppointmentCard';
 
 interface Appointment {
     id: number;
@@ -18,13 +18,20 @@ interface Appointment {
     updatedAt: string;
 }
 
-interface Props {
-    appointments: Appointment[];
-}
-
-const DoctorAppointment: React.FC<Props> = ({ appointments }) => {
+const DoctorAppointments: React.FC = () => {
     const { t } = useTranslation();
     const { user, accessToken } = useAuth();
+    const [appointments, setAppointments] = useState<Appointment[]>([]);
+
+    useEffect(() => {
+        if (!user) return;
+        api
+            .get(`/appointments/doctor/${user.id}`, {
+                headers: { Authorization: `Bearer ${accessToken}` },
+            })
+            .then((res) => setAppointments(res.data))
+            .catch((err) => console.error('Appointments fetch error:', err));
+    }, [user, accessToken]);
 
     const handleConformation = async (appointmentId: number) => {
         if (!user || !accessToken) return;
@@ -41,7 +48,7 @@ const DoctorAppointment: React.FC<Props> = ({ appointments }) => {
     };
 
     return (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="bg-white rounded-lg shadow divide-y">
             {appointments.map((appt) => (
                 <DoctorAppointmentCard
                     key={appt.id}
@@ -53,4 +60,4 @@ const DoctorAppointment: React.FC<Props> = ({ appointments }) => {
     );
 };
 
-export default DoctorAppointment;
+export default DoctorAppointments;

--- a/src/pages/DoctorPage/DoctorHomePage.tsx
+++ b/src/pages/DoctorPage/DoctorHomePage.tsx
@@ -1,121 +1,31 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import dayjs from 'dayjs';
-import {useAuth} from "../../contexts/ContextsAuth";
-import {API_ENDPOINTS} from "../../constants/apiConfig";
-import api from "../../services/api";
-
-interface Appointment {
-    id: number;
-    patientId: number;
-    doctorId: number;
-    startTime: string;
-    endTime: string;
-    reason: string;
-    notes: string;
-    status: string;
-    cancellationReason: string | null;
-    createdAt: string;
-    updatedAt: string;
-}
+import DoctorNavbar from '../../components/Doctor/DoctorNavbar';
+import DoctorAppointments from '../../components/Doctor/DoctorAppointments';
 
 const DoctorDashboard: React.FC = () => {
-    const { t, i18n } = useTranslation();
-    const { user, accessToken } = useAuth();
-    const [appointments, setAppointments] = useState<Appointment[]>([]);
+    const { t } = useTranslation();
+    const [section, setSection] = useState('overview');
 
-    useEffect(() => {
-        if (!user) return;
-        api.get(API_ENDPOINTS.appointmentsByDoctor(user.id), {
-            headers: { Authorization: `Bearer ${accessToken}` },
-        }).then((res) => setAppointments(res.data));
-    }, [user, accessToken]);
-
-    const handleConfirm = async (id: number) => {
-        if(!user)
-            return
-        try {
-            await api.put(`/appointments/${user.id}/confirm/${id}`, null, {
-                headers: { Authorization: `Bearer ${accessToken}` },
-            });
-            setAppointments((prev) =>
-                prev.map((appt) =>
-                    appt.id === id ? { ...appt, status: 'CONFIRMED' } : appt
-                )
-            );
-        } catch (err) {
-            console.error('Confirm error:', err);
+    const renderSection = () => {
+        switch (section) {
+            case 'appointments':
+                return <DoctorAppointments />;
+            case 'patients':
+                return <div className="text-xl font-semibold">{t('patients')}</div>;
+            case 'visits':
+                return <div className="text-xl font-semibold">{t('visits')}</div>;
+            default:
+                return <div className="text-xl font-semibold">{t('overview')}</div>;
         }
     };
 
-    const formatDate = (iso: string) => dayjs(iso).format('DD MMM YY');
-    const formatTime = (iso: string) => dayjs(iso).format('h:mm A');
-
     return (
         <div className="flex min-h-screen bg-gray-50 font-sans">
-            {/* Sidebar */}
-            <aside className="w-60 bg-white shadow p-6 space-y-4">
-                <h2 className="text-xl font-bold text-blue-600">{t('menu')}</h2>
-                <nav className="space-y-2 text-sm">
-                    <a href="#" className="block text-gray-700 hover:text-blue-600 font-medium">
-                        {t('overview')}
-                    </a>
-                    <a href="#" className="block text-gray-700 hover:text-blue-600">{t('todayAppointments')}</a>
-                    <a href="#" className="block text-blue-700 font-bold">{t('patients')}</a>
-                </nav>
-                <button onClick={() => i18n.changeLanguage(i18n.language === 'en' ? 'ar' : 'en')}
-                        className="text-sm text-blue-600 underline mt-6">
-                    {i18n.language === 'en' ? 'العربية' : 'English'}
-                </button>
-            </aside>
-
-            {/* Main Content */}
+            <DoctorNavbar selected={section} onSelect={setSection} />
             <main className="flex-1 p-6">
-                <div className="flex justify-between items-center mb-4">
-                    <h1 className="text-2xl font-semibold">{t('managePatients')}</h1>
-                    <button className="bg-blue-600 text-white px-4 py-2 rounded">{t('addNewPatient')}</button>
-                </div>
-
-                {/* Filters */}
-                <div className="flex flex-wrap gap-4 mb-6">
-                    <input className="border px-3 py-2 rounded text-sm" placeholder={t('search')} />
-                    <select className="border px-3 py-2 rounded text-sm">
-                        <option>{t('allStatuses')}</option>
-                        <option>Pending</option>
-                        <option>Confirmed</option>
-                    </select>
-                </div>
-
-                {/* Appointment Cards */}
-                <div className="bg-white rounded-lg shadow overflow-hidden divide-y">
-                    {appointments.map((appt) => (
-                        <div
-                            key={appt.id}
-                            className="flex flex-col md:flex-row md:items-center justify-between p-4 hover:bg-gray-50 transition"
-                        >
-                            <div className="flex flex-wrap items-center gap-6 text-sm">
-                                <span className="w-24">{formatDate(appt.startTime)}</span>
-                                <span className="w-20">{formatTime(appt.startTime)}</span>
-                                <span className="w-24">{appt.reason || 'FUP'}</span>
-                                <span className="w-36">{appt.patientId}</span>
-                                <span className="w-24 text-gray-500">{appt.status}</span>
-                            </div>
-
-                            <div className="mt-4 md:mt-0 flex gap-2">
-                                <button
-                                    onClick={() => handleConfirm(appt.id)}
-                                    className="bg-blue-600 text-white px-4 py-1 rounded text-sm hover:bg-blue-700"
-                                >
-                                    {t('confirm')}
-                                </button>
-                                <button className="bg-gray-600 text-white px-4 py-1 rounded text-sm hover:bg-gray-700">
-                                    {t('checkIn')}
-                                </button>
-                            </div>
-                        </div>
-                    ))}
-                </div>
+                {renderSection()}
             </main>
         </div>
     );


### PR DESCRIPTION
## Summary
- improve doctor dashboard to switch sections from sidebar
- move appointment fetching into `DoctorAppointments` component
- display each appointment row via `DoctorAppointmentCard`
- clean up doctor home page layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68580f1c861883318f46e408867b1f5d