### PR TITLE
Refactor API calls into services

### DIFF
--- a/src/components/Doctor/DoctorCard.tsx
+++ b/src/components/Doctor/DoctorCard.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import api from '../../services/api';
-import { API_ENDPOINTS } from '../../constants/apiConfig';
+import { getDoctor, getAvailableSlots } from '../../services/doctorService';
 import dayjs from "dayjs";
 
 interface DoctorData {
@@ -26,21 +25,19 @@ const DoctorCard: React.FC<{ doctorId: string }> = ({ doctorId }) => {
     const [showAll, setShowAll] = useState(false);
 
     useEffect(() => {
-        api
-            .get(API_ENDPOINTS.doctor(doctorId))
-            .then((res) => setDoctor(res.data))
+        getDoctor(doctorId)
+            .then(setDoctor)
             .catch((err) => console.error('Doctor fetch error:', err));
 
-        api
-            .get(API_ENDPOINTS.availableSlots(doctorId))
+        getAvailableSlots(doctorId)
             .then((res) => {
-                const rawSlots: string[] = Array.isArray(res.data) ? res.data : [];
+                const rawSlots: string[] = Array.isArray(res) ? res : [];
                 const grouped: { [key: string]: string[] } = {};
 
                 rawSlots.forEach((datetime) => {
                     const [date, time] = datetime.split('T');
                     if (!grouped[date]) grouped[date] = [];
-                    grouped[date].push(time.slice(0, 5)); // "09:00:00" → "09:00"
+                    grouped[date].push(time.slice(0, 5));
                 });
 
                 const groupedArray: GroupedSlots[] = Object.entries(grouped).map(([date, times]) => ({

--- a/src/components/Drug/DrugCard.tsx
+++ b/src/components/Drug/DrugCard.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { useAuth } from '../../contexts/ContextsAuth';
-import api from '../../services/api';
-import {API_ENDPOINTS} from "../../constants/apiConfig";
+import { addDrugToPatient } from '../../services/drugService';
 
 export interface Drug {
     drugId: number;
@@ -27,15 +26,13 @@ const DrugCard: React.FC<DrugCardProps> = ({ drug }) => {
 
         setLoading(true);
         try {
-            await api.post(
-                `${API_ENDPOINTS.patients}/${user.id}/drugs`,
+            await addDrugToPatient(
+                user.id,
                 {
                     drugId: drug.drugId,
                     frequency: Number(frequency)
                 },
-                {
-                    headers: { Authorization: `Bearer ${accessToken}` }
-                }
+                accessToken!
             );
             alert('✅ Drug added successfully');
             setShowModal(false);

--- a/src/components/HomePage/FirstSection.tsx
+++ b/src/components/HomePage/FirstSection.tsx
@@ -3,8 +3,7 @@ import { useTranslation } from "react-i18next";
 import { COLORS } from "../../constants/theme";
 import SearchBar from "../SearchBar";
 import { useState, useEffect } from "react";
-import api from "../../services/api";
-import { API_ENDPOINTS } from "../../constants/apiConfig";
+import { getDoctors } from '../../services/doctorService';
 import DoctorList from "../Doctor/DoctorList";
 
 interface Doctor {
@@ -31,12 +30,10 @@ const FirstSection = () => {
             }
 
             try {
-                const res = await api.get(`${API_ENDPOINTS.doctors}/search?q=${encodeURIComponent(searchQuery)}`, {
-                    headers: { Authorization: `Bearer ${accessToken}` },
-                });
-                setResults(res.data);
+                const res = await getDoctors(searchQuery, undefined, accessToken!);
+                setResults(res);
             } catch (err) {
-                console.error("Search failed", err);
+                console.error('Search failed', err);
                 setResults([]);
             }
         };

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import LabeledInput from './LabeledInput';
 import Button from './Button';
-import { BASE_URL } from '../constants/apiConfig';
+import { loginUser } from '../services/authService';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/ContextsAuth';
 
@@ -26,18 +26,7 @@ const LoginForm: React.FC<Props> = ({ onSwitch }) => {
         e.preventDefault();
         setError('');
         try {
-            const res = await fetch(`${BASE_URL}/auth/login`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(formData),
-            });
-
-            if (!res.ok) {
-                const err = await res.text();
-                throw new Error(err || 'Login failed');
-            }
-
-            const data = await res.json();
+            const data = await loginUser(formData);
             login(data); // save user in context
             console.log(data.user.role)
             // Navigate based on user role

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import LabeledInput from './LabeledInput';
 import Button from './Button';
-import { BASE_URL } from "../constants/apiConfig";
+import { signupUser } from '../services/authService';
 import { useNavigate } from 'react-router-dom';
 
 type Props = {
@@ -56,13 +56,7 @@ const SignupForm: React.FC<Props> = ({ onSwitch }) => {
         };
 
         try {
-            const res = await fetch(`${BASE_URL}/auth/register`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload),
-            });
-
-            if (!res.ok) throw new Error('Signup failed');
+            await signupUser(payload);
 
             alert('Account created!');
             navigate('/verify-otp', {

--- a/src/pages/DoctorPage/DoctorHomePage.tsx
+++ b/src/pages/DoctorPage/DoctorHomePage.tsx
@@ -2,8 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import DoctorNavbar from '../../components/Doctor/DoctorNavbar';
-import { API_ENDPOINTS } from '../../constants/apiConfig';
-import api from '../../services/api';
+import { getAppointmentsByDoctor, confirmAppointment } from '../../services/appointmentService';
 import { useAuth } from '../../contexts/ContextsAuth';
 import AppointmentTable, {Appointment} from "../../components/Doctor/DoctorAppointments";
 
@@ -15,24 +14,15 @@ const DoctorDashboard: React.FC = () => {
 
     useEffect(() => {
         if (!user) return;
-        api
-            .get(API_ENDPOINTS.appointmentsByDoctor(user.id), {
-                headers: { Authorization: `Bearer ${accessToken}` },
-            })
-            .then((res) => setAppointments(res.data))
+        getAppointmentsByDoctor(user.id, accessToken!)
+            .then(setAppointments)
             .catch((err) => console.error('Appointments fetch error:', err));
     }, [user, accessToken]);
 
     const handleConformation = async (appointmentId: number) => {
         if (!user || !accessToken) return;
         try {
-            const response = await api.put(
-                `/appointments/${user.id}/confirm/${appointmentId}`,
-                null,
-                { headers: { Authorization: `Bearer ${accessToken}` } }
-            );
-
-            const updated = response.data;
+            const updated = await confirmAppointment(user.id, appointmentId, accessToken!);
             setAppointments((prev) =>
                 prev.map((appt) => (appt.id === updated.id ? updated : appt))
             );

--- a/src/pages/DoctorsPage.tsx
+++ b/src/pages/DoctorsPage.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import api from '../services/api';
-import { API_ENDPOINTS } from '../constants/apiConfig';
+import { getDoctors } from '../services/doctorService';
 import { useAuth } from '../contexts/ContextsAuth';
 import Navbar from '../components/Navbar';
 import SearchBar from '../components/SearchBar';
@@ -24,25 +23,11 @@ const DoctorsPage: React.FC = () => {
     const { t } = useTranslation();
 
     useEffect(() => {
-        const fetchDoctors = async () => {
+        const fetchDoctorsData = async () => {
             try {
-                const params = new URLSearchParams();
-                if (search) params.append('q', search);
-                if (specialtyFilter) params.append('specialty', specialtyFilter);
-
-                const endpoint =
-                    search || specialtyFilter
-                        ? `${API_ENDPOINTS.doctors}/search?${params.toString()}`
-                        : API_ENDPOINTS.doctors;
-
-                const res = await api.get(endpoint, {
-                    headers: { Authorization: `Bearer ${accessToken}` },
-                });
-
-                console.log('Fetched doctors:', res.data);
-
-                const data = Array.isArray(res.data) ? res.data : res.data?.doctors || [];
-                setDoctors(data);
+                const data = await getDoctors(search, specialtyFilter, accessToken!);
+                const doctorsArray = Array.isArray(data) ? data : data?.doctors || [];
+                setDoctors(doctorsArray);
                 setCurrentPage(1);
             } catch (err) {
                 console.error('Failed to fetch doctors:', err);
@@ -50,7 +35,7 @@ const DoctorsPage: React.FC = () => {
             }
         };
 
-        fetchDoctors();
+        fetchDoctorsData();
     }, [accessToken, search, specialtyFilter]);
 
     const specialties = Array.from(

--- a/src/pages/DrugPage.tsx
+++ b/src/pages/DrugPage.tsx
@@ -2,8 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Navbar from '../components/Navbar';
 import SearchBar from '../components/SearchBar';
 import DrugCard, { Drug } from '../components/Drug/DrugCard';
-import api from '../services/api';
-import { API_ENDPOINTS } from '../constants/apiConfig';
+import { getDrugs } from '../services/drugService';
 import Button from "../components/Button";
 import {useTranslation} from "react-i18next";
 
@@ -18,14 +17,10 @@ const DrugPage: React.FC = () => {
 
     useEffect(() => {
         setLoading(true);
-        const endpoint = searchQuery
-            ? `${API_ENDPOINTS.drugs}/search?q=${encodeURIComponent(searchQuery)}`
-            : API_ENDPOINTS.drugs;
-
-        api.get(endpoint)
-            .then((res) => {
-                setDrugs(res.data);
-                setCurrentPage(1); // reset to page 1 on new search
+        getDrugs(searchQuery)
+            .then((data) => {
+                setDrugs(data);
+                setCurrentPage(1);
             })
             .catch((err) => console.error('Drug fetch failed', err))
             .finally(() => setLoading(false));

--- a/src/pages/PatientPage/AddDrugPage.tsx
+++ b/src/pages/PatientPage/AddDrugPage.tsx
@@ -2,9 +2,8 @@ import React, { useState } from 'react';
 import Navbar from '../../components/Navbar';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import api from '../../services/api';
 import { useAuth } from '../../contexts/ContextsAuth';
-import { API_ENDPOINTS } from '../../constants/apiConfig';
+import { addDrugToPatient } from '../../services/drugService';
 import { COLORS } from '../../constants/theme';
 
 const AddDrugPage: React.FC = () => {
@@ -25,21 +24,14 @@ const AddDrugPage: React.FC = () => {
             return;
         }
 
-        const body = {
-            patientId: user.id,
-            drugName,
-            frequency: Number(frequency),
-            startDate: startDate || null,
-            endDate: endDate || null,
-            dosage: dosage || null,
-            drugStatus: null,
-            drugAlarms: []
-        };
-
         try {
-            await api.post(`${API_ENDPOINTS.patients}/${user.id}/drugs`, body, {
-                headers: { Authorization: `Bearer ${accessToken}` }
-            });
+            await addDrugToPatient(user.id, {
+                drugName,
+                frequency: Number(frequency),
+                startDate: startDate || null,
+                endDate: endDate || null,
+                dosage: dosage || null,
+            }, accessToken!);
             alert(t('addSuccess'));
             navigate('/my-drugs');
         } catch (err) {

--- a/src/pages/PatientPage/AppointmentBookingPage.tsx
+++ b/src/pages/PatientPage/AppointmentBookingPage.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import dayjs from 'dayjs';
-import api from '../../services/api';
-import { API_ENDPOINTS } from '../../constants/apiConfig';
+import { getDoctorAppointments, getDoctor } from '../../services/doctorService';
 import { useAuth } from '../../contexts/ContextsAuth';
 import Navbar from '../../components/Navbar';
 import { useTranslation } from 'react-i18next';
@@ -20,18 +19,12 @@ const AppointmentBookingPage: React.FC = () => {
 
     useEffect(() => {
         if (!doctorId) return;
-        api
-            .get(API_ENDPOINTS.doctorAppointments(doctorId), {
-                headers: { Authorization: `Bearer ${accessToken}` },
-            })
-            .then((res) => setAllAppointments(res.data))
+        getDoctorAppointments(doctorId, accessToken!)
+            .then(setAllAppointments)
             .catch((err) => console.error(err));
 
-        api
-            .get(API_ENDPOINTS.doctor(doctorId), {
-                headers: { Authorization: `Bearer ${accessToken}` },
-            })
-            .then((res) => setDoctor(res.data))
+        getDoctor(doctorId, accessToken!)
+            .then(setDoctor)
             .catch((err) => console.error(err));
     }, [doctorId, accessToken]);
 

--- a/src/pages/PatientPage/BookingPage.tsx
+++ b/src/pages/PatientPage/BookingPage.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import dayjs from 'dayjs';
 import Navbar from '../../components/Navbar';
-import api from '../../services/api';
-import { API_ENDPOINTS } from '../../constants/apiConfig';
+import { getDoctor } from '../../services/doctorService';
+import { bookAppointment } from '../../services/appointmentService';
 import { useAuth } from '../../contexts/ContextsAuth';
 import { useTranslation } from 'react-i18next';
 
@@ -30,11 +30,8 @@ const BookingPage: React.FC = () => {
 
     useEffect(() => {
         if (!doctorId) return;
-        api
-            .get(API_ENDPOINTS.doctor(doctorId), {
-                headers: { Authorization: `Bearer ${accessToken}` },
-            })
-            .then((res) => setDoctor(res.data))
+        getDoctor(doctorId, accessToken!)
+            .then(setDoctor)
             .catch((err) => console.error(err));
     }, [doctorId, accessToken]);
 
@@ -54,9 +51,7 @@ const BookingPage: React.FC = () => {
         };
 
         try {
-            await api.post(API_ENDPOINTS.bookAppointment(user.id), body, {
-                headers: { Authorization: `Bearer ${accessToken}` },
-            });
+            await bookAppointment(user.id, body, accessToken!);
             navigate('/my-appointments');
         } catch (err) {
             console.error(err);

--- a/src/pages/PatientPage/MyDrugPage.tsx
+++ b/src/pages/PatientPage/MyDrugPage.tsx
@@ -2,8 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Navbar from "../../components/Navbar";
 import { useAuth } from "../../contexts/ContextsAuth";
 import { useTranslation } from "react-i18next";
-import api from "../../services/api";
-import { API_ENDPOINTS } from "../../constants/apiConfig";
+import { getPatientDrugs } from '../../services/drugService';
 import { useNavigate } from 'react-router-dom';
 import { COLORS } from '../../constants/theme';
 
@@ -28,11 +27,8 @@ function MyDrugPage() {
     useEffect(() => {
         if (!user) return;
 
-        api
-            .get(`/patients/${user.id}/drugs`, {
-                headers: { Authorization: `Bearer ${accessToken}` },
-            })
-            .then((res) => setDrugs(res.data))
+        getPatientDrugs(user.id, accessToken!)
+            .then(setDrugs)
             .catch((err) => console.error('Failed to load user drugs:', err));
     }, [user, accessToken]);
 

--- a/src/pages/PatientPage/ProfilePage.tsx
+++ b/src/pages/PatientPage/ProfilePage.tsx
@@ -3,8 +3,7 @@ import Navbar from '../../components/Navbar';
 import { useAuth } from '../../contexts/ContextsAuth';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
-import {BASE_URL} from "../../constants/apiConfig";
+import { uploadProfileImage } from '../../services/userService';
 
 const ProfilePage: React.FC = () => {
     const { user, logout } = useAuth();
@@ -31,15 +30,10 @@ const ProfilePage: React.FC = () => {
     const handleUpload = async () => {
         if (!selectedFile || !user) return;
 
-        const formData = new FormData();
-        formData.append("image", selectedFile);
-
         try {
-            const response = await axios.post(`${BASE_URL}/users/${user.id}/addImage`, formData, {
-                headers: { "Content-Type": "multipart/form-data", Authorization: `Bearer ${accessToken}`  }
-            });
+            const response = await uploadProfileImage(user.id, selectedFile, accessToken!);
             setUploadMessage("Image uploaded successfully!");
-            setImageUrl(response.data); // path returned from backend
+            setImageUrl(response); // path returned from backend
         } catch (error) {
             setUploadMessage("Image upload failed.");
             console.error(error);

--- a/src/pages/VerifyOtpPage.tsx
+++ b/src/pages/VerifyOtpPage.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import Navbar from '../components/Navbar';
 import LabeledInput from '../components/LabeledInput';
 import Button from '../components/Button';
-import { BASE_URL } from '../constants/apiConfig';
+import { verifyOtp } from '../services/authService';
 
 const VerifyOtpPage: React.FC = () => {
     const location = useLocation();
@@ -14,14 +14,7 @@ const VerifyOtpPage: React.FC = () => {
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         try {
-            const res = await fetch(`${BASE_URL}/auth/verify-otp`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ username, otp }),
-            });
-
-            if (!res.ok) throw new Error('Verification failed');
-
+            await verifyOtp(username, otp);
             alert('Account verified!');
             navigate('/login');
         } catch {

--- a/src/services/appointmentService.ts
+++ b/src/services/appointmentService.ts
@@ -1,0 +1,46 @@
+import api from './api';
+import { API_ENDPOINTS } from '../constants/apiConfig';
+
+export const getAppointmentsByPatient = async (id: number | string, token: string) => {
+  const res = await api.get(API_ENDPOINTS.appointmentByPatient(id), { headers: { Authorization: `Bearer ${token}` } });
+  return res.data;
+};
+
+export const getAppointmentsByDoctor = async (id: number | string, token: string) => {
+  const res = await api.get(API_ENDPOINTS.appointmentsByDoctor(id), { headers: { Authorization: `Bearer ${token}` } });
+  return res.data;
+};
+
+export interface BookAppointmentPayload {
+  patientId: number | string;
+  doctorId: number | string;
+  startTime: string;
+  reason: string;
+  notes?: string | null;
+  cancellationReason?: string | null;
+}
+
+export const bookAppointment = async (userId: number | string, payload: BookAppointmentPayload, token: string) => {
+  const res = await api.post(API_ENDPOINTS.bookAppointment(userId), payload, { headers: { Authorization: `Bearer ${token}` } });
+  return res.data;
+};
+
+export const cancelAppointment = async (userId: number | string, appointmentId: number | string, name: string, token: string) => {
+  const res = await api.put(`/appointments/${userId}/${appointmentId}/cancel-by-patient`, { name }, { headers: { Authorization: `Bearer ${token}` } });
+  return res.data;
+};
+
+export const confirmAppointment = async (doctorId: number | string, appointmentId: number | string, token: string) => {
+  const res = await api.put(`/appointments/${doctorId}/confirm/${appointmentId}`, null, { headers: { Authorization: `Bearer ${token}` } });
+  return res.data;
+};
+
+export const rescheduleAppointment = async (
+  userId: number | string,
+  appointmentId: number | string,
+  payload: BookAppointmentPayload,
+  token: string
+) => {
+  const res = await api.put(`/appointments/${userId}/reschedule/${appointmentId}`, payload, { headers: { Authorization: `Bearer ${token}` } });
+  return res.data;
+};

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,37 @@
+import api from './api';
+
+export interface LoginPayload {
+  username: string;
+  password: string;
+}
+
+export interface SignupPayload {
+  username: string;
+  password: string;
+  name: string;
+  email: string;
+  phoneNumber: string;
+  gender: string;
+  role: string;
+}
+
+export const loginUser = async (payload: LoginPayload) => {
+  const res = await api.post('/auth/login', payload, {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  return res.data;
+};
+
+export const signupUser = async (payload: SignupPayload) => {
+  const res = await api.post('/auth/register', payload, {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  return res.data;
+};
+
+export const verifyOtp = async (username: string, otp: string) => {
+  const res = await api.post('/auth/verify-otp', { username, otp }, {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  return res.data;
+};

--- a/src/services/doctorService.ts
+++ b/src/services/doctorService.ts
@@ -1,0 +1,26 @@
+import api from './api';
+import { API_ENDPOINTS } from '../constants/apiConfig';
+
+export const getDoctors = async (search?: string, specialty?: string, token?: string) => {
+  const params = new URLSearchParams();
+  if (search) params.append('q', search);
+  if (specialty) params.append('specialty', specialty);
+  const endpoint = search || specialty ? `${API_ENDPOINTS.doctors}/search?${params.toString()}` : API_ENDPOINTS.doctors;
+  const res = await api.get(endpoint, token ? { headers: { Authorization: `Bearer ${token}` } } : undefined);
+  return res.data;
+};
+
+export const getDoctor = async (id: number | string, token?: string) => {
+  const res = await api.get(API_ENDPOINTS.doctor(id), token ? { headers: { Authorization: `Bearer ${token}` } } : undefined);
+  return res.data;
+};
+
+export const getDoctorAppointments = async (id: number | string, token: string) => {
+  const res = await api.get(API_ENDPOINTS.doctorAppointments(id), { headers: { Authorization: `Bearer ${token}` } });
+  return res.data;
+};
+
+export const getAvailableSlots = async (id: number | string, token?: string) => {
+  const res = await api.get(API_ENDPOINTS.availableSlots(id), token ? { headers: { Authorization: `Bearer ${token}` } } : undefined);
+  return res.data;
+};

--- a/src/services/drugService.ts
+++ b/src/services/drugService.ts
@@ -1,0 +1,18 @@
+import api from './api';
+import { API_ENDPOINTS } from '../constants/apiConfig';
+
+export const getDrugs = async (search?: string) => {
+  const endpoint = search ? `${API_ENDPOINTS.drugs}/search?q=${encodeURIComponent(search)}` : API_ENDPOINTS.drugs;
+  const res = await api.get(endpoint);
+  return res.data;
+};
+
+export const addDrugToPatient = async (patientId: number | string, payload: { drugId?: number; drugName?: string; frequency: number; startDate?: string | null; endDate?: string | null; dosage?: string | null; }, token: string) => {
+  const res = await api.post(`${API_ENDPOINTS.patients}/${patientId}/drugs`, payload, { headers: { Authorization: `Bearer ${token}` } });
+  return res.data;
+};
+
+export const getPatientDrugs = async (patientId: number | string, token: string) => {
+  const res = await api.get(`${API_ENDPOINTS.patients}/${patientId}/drugs`, { headers: { Authorization: `Bearer ${token}` } });
+  return res.data;
+};

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,0 +1,11 @@
+import api from './api';
+import { BASE_URL } from '../constants/apiConfig';
+
+export const uploadProfileImage = async (userId: number | string, file: File, token: string) => {
+  const formData = new FormData();
+  formData.append('image', file);
+  const res = await api.post(`/users/${userId}/addImage`, formData, {
+    headers: { 'Content-Type': 'multipart/form-data', Authorization: `Bearer ${token}` },
+  });
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- centralize authentication requests in `authService`
- add doctor, appointment, drug and user services
- refactor pages and components to use the new service functions
- remove fetch usage from UI components for cleaner code

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685d67577e408331b4c26a2e1316b69d