### PR TITLE
Add patient profile view for doctor dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import DoctorsPage from './pages/DoctorsPage';
 import AppointmentBookingPage from './pages/PatientPage/AppointmentBookingPage';
 import BookingPage from './pages/PatientPage/BookingPage';
 import AppointmentsPage from './pages/AppointmentsPage';
+import DoctorPatientPage from "./pages/DoctorPage/DoctorPatientPage";
 import ProfilePage from './pages/PatientPage/ProfilePage';
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import DrugPage from "./pages/DrugPage";
@@ -45,6 +46,7 @@ const App: React.FC = () => {
             <Route path="/verify-otp" element={<VerifyOtpPage />} />
             <Route path="/my-drug" element={<MyDrugPage />}/>
             <Route path="/doctor-home" element={<DoctorHomePage/>}/>
+            <Route path="/doctor-home/patient/:id" element={<DoctorPatientPage />} />
         </Routes>
     </Router>
     );

--- a/src/components/Doctor/DoctorPatientTable.tsx
+++ b/src/components/Doctor/DoctorPatientTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from "react-router-dom";
 
 export interface Patient {
     id: number;
@@ -14,6 +15,7 @@ interface Props {
 
 const DoctorPatientTable: React.FC<Props> = ({ data }) => {
     const { t } = useTranslation();
+    const navigate = useNavigate();
 
     if (data.length === 0) {
         return (
@@ -36,7 +38,7 @@ const DoctorPatientTable: React.FC<Props> = ({ data }) => {
                 </thead>
                 <tbody className="divide-y divide-gray-200">
                 {data.map((patient, index) => (
-                    <tr key={patient.id} className="hover:bg-gray-50">
+                    <tr key={patient.id} className="hover:bg-gray-50 cursor-pointer" onClick={() => navigate(`/doctor-home/patient/${patient.id}`)}>
                         <td className="px-6 py-4 font-medium">{index + 1}</td>
                         <td className="px-6 py-4">{patient.name}</td>
                         <td className="px-6 py-4">{patient.phoneNumber}</td>

--- a/src/components/Doctor/PatientProfilePage.tsx
+++ b/src/components/Doctor/PatientProfilePage.tsx
@@ -1,103 +1,122 @@
 import React from 'react';
+import dayjs from 'dayjs';
 import { SectionCard } from './SectionCard';
 import { PatientHeader } from './PatientHeader';
-import FileListCard from "./FileListCard";
+import FileListCard from './FileListCard';
 
-const PatientProfilePage: React.FC = () => (
+export interface AppointmentInfo {
+  id: number;
+  patientId: number;
+  doctorId: number;
+  startTime: string;
+  endTime: string;
+  reason: string | null;
+  notes: string;
+  status: string;
+}
+
+export interface PatientInfo {
+  patientId: number;
+  address: string | null;
+  bloodType: string | null;
+  weight: number;
+  name: string;
+  phoneNumber: string;
+  dob: string | null;
+  gender: string;
+  appointments: AppointmentInfo[];
+  imageUrl: string | null;
+}
+
+interface Props {
+  patient: PatientInfo | null;
+}
+
+const PatientProfilePage: React.FC<Props> = ({ patient }) => {
+  if (!patient) {
+    return <main className="p-6">Loading...</main>;
+  }
+
+  return (
     <main className="flex-1 p-6 bg-gray-50 overflow-y-auto">
-        <PatientHeader />
-
-        <div className="flex flex-col lg:flex-row gap-6 min-h-[600px]">
-            {/* Left Column */}
-            <div className="w-full lg:w-2/3 flex flex-col gap-6">
-                <div className="flex flex-col md:flex-row gap-6">
-                    <SectionCard className="min-h-[220px]">
-                        <div className="text-center md:text-left">
-                            <img
-                                src="/assets/pic.jpg"
-                                alt="Patient Photo"
-                                className="w-24 h-24 rounded-full mx-auto md:mx-0 mb-4"
-                            />
-                            <h2 className="text-lg font-semibold">Kate Prokopchuk</h2>
-                            <p className="text-sm text-gray-600 mt-2">+38 (083) 23 45 678</p>
-                            <p className="text-sm text-gray-600">katepro@gmail.com</p>
-                        </div>
-                    </SectionCard>
-
-                    <SectionCard title="General Information" className="min-h-[220px]">
-                        <div className="text-sm space-y-1">
-                            <p><strong>Date of Birth:</strong> 23.07.1994</p>
-                            <p><strong>Address:</strong> Lviv, Chornovola street, 67</p>
-                            <p><strong>Registration Date:</strong> Thursday, May 25</p>
-                        </div>
-                    </SectionCard>
+      <PatientHeader />
+      <div className="flex flex-col lg:flex-row gap-6 min-h-[600px]">
+        <div className="w-full lg:w-2/3 flex flex-col gap-6">
+          <div className="flex flex-col md:flex-row gap-6">
+            <SectionCard className="min-h-[220px]">
+              <div className="text-center md:text-left">
+                <img
+                  src={patient.imageUrl || '/assets/pic.jpg'}
+                  alt="Patient Photo"
+                  className="w-24 h-24 rounded-full mx-auto md:mx-0 mb-4"
+                />
+                <h2 className="text-lg font-semibold">{patient.name}</h2>
+                <p className="text-sm text-gray-600 mt-2">{patient.phoneNumber}</p>
+              </div>
+            </SectionCard>
+            <SectionCard title="General Information" className="min-h-[220px]">
+              <div className="text-sm space-y-1">
+                <p>
+                  <strong>Date of Birth:</strong>{' '}
+                  {patient.dob ? dayjs(patient.dob).format('DD.MM.YYYY') : 'N/A'}
+                </p>
+                <p>
+                  <strong>Address:</strong> {patient.address || 'N/A'}
+                </p>
+              </div>
+            </SectionCard>
+          </div>
+          <SectionCard>
+            <div className="flex border-b mb-4 text-sm font-medium text-gray-500">
+              <button className="border-b-2 border-blue-500 text-blue-600 px-4 py-2">
+                Future visits ({patient.appointments.length})
+              </button>
+            </div>
+            <div className="space-y-4 flex-1 overflow-y-auto">
+              {patient.appointments.map((visit) => (
+                <div
+                  key={visit.id}
+                  className="border rounded-lg p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between bg-blue-50"
+                >
+                  <div className="mb-2 sm:mb-0">
+                    <p className="text-xs text-gray-500">
+                      {dayjs(visit.startTime).format('HH:mm')}-
+                      {dayjs(visit.endTime).format('HH:mm')}
+                    </p>
+                    <p className="text-lg font-semibold text-textDark">
+                      {dayjs(visit.startTime).format('DD MMM YYYY')}
+                    </p>
+                  </div>
+                  <div className="flex-1 sm:mx-4">
+                    <p className="text-sm text-gray-600">
+                      <strong>Service:</strong> {visit.reason || 'N/A'}
+                    </p>
+                  </div>
+                  <span className="inline-block text-xs font-semibold text-green-700 bg-green-100 rounded-full px-3 py-1 mt-2 sm:mt-0">
+                    {visit.status}
+                  </span>
                 </div>
-
-                <SectionCard>
-                    <div className="flex border-b mb-4 text-sm font-medium text-gray-500">
-                        <button className="border-b-2 border-blue-500 text-blue-600 px-4 py-2">Future visits (2)</button>
-                        <button className="px-4 py-2 hover:text-blue-600">Past visits (15)</button>
-                        <button className="px-4 py-2 hover:text-blue-600">Planned treatments</button>
-                    </div>
-
-                    <div className="space-y-4 flex-1 overflow-y-auto">
-                        {[{
-                            time: "11:00-12:30",
-                            date: "26 Jun 2023",
-                            service: "Treatment and cleaning of canals",
-                            doctor: "Oksana Ma...",
-                        }, {
-                            time: "11:00-12:30",
-                            date: "27 Jul 2023",
-                            service: "Teeth whitening",
-                            doctor: "Max Och...",
-                        }].map((visit, idx) => (
-                            <div key={idx} className="border rounded-lg p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between bg-blue-50">
-                                <div className="mb-2 sm:mb-0">
-                                    <p className="text-xs text-gray-500">{visit.time}</p>
-                                    <p className="text-lg font-semibold text-textDark">{visit.date}</p>
-                                </div>
-                                <div className="flex-1 sm:mx-4">
-                                    <p className="text-sm text-gray-600"><strong>Service:</strong> {visit.service}</p>
-                                    <p className="text-sm text-gray-600"><strong>Doctor:</strong> {visit.doctor}</p>
-                                </div>
-                                <span className="inline-block text-xs font-semibold text-green-700 bg-green-100 rounded-full px-3 py-1 mt-2 sm:mt-0">Scheduled</span>
-                            </div>
-                        ))}
-                    </div>
-                </SectionCard>
+              ))}
             </div>
-
-            {/* Right Column */}
-            <div className="w-full lg:w-1/3 flex flex-col gap-6">
-                <SectionCard title="Anamnesis">
-                    <div className="text-sm space-y-1">
-                        <p><strong>Allergies:</strong> Nuts, pollen</p>
-                        <p><strong>Chronic diseases:</strong> Asthma</p>
-                        <p><strong>Blood type:</strong> H</p>
-                        <p><strong>Past illnesses:</strong> Corona virus</p>
-                    </div>
-                </SectionCard>
-
-                <FileListCard
-                    header="Files"
-                    files={[
-                        { name: "Check Up Result.pdf", size: "123kb", url: "#" },
-                        { name: "Medical Prescriptions.pdf", size: "123kb", url: "#" },
-                        { name: "Check Up Result.pdf", size: "123kb", url: "#" },
-                    ]}
-                />
-
-                <FileListCard
-                    header="Notes"
-                    files={[
-                        { name: "Note 31.06.23.pdf", size: "123kb", url: "#" },
-                        { name: "Note 23.06.23.pdf", size: "123kb", url: "#" },
-                    ]}
-                />
-            </div>
+          </SectionCard>
         </div>
+        <div className="w-full lg:w-1/3 flex flex-col gap-6">
+          <SectionCard title="Anamnesis">
+            <div className="text-sm space-y-1">
+              <p>
+                <strong>Blood type:</strong> {patient.bloodType || 'N/A'}
+              </p>
+              <p>
+                <strong>Weight:</strong> {patient.weight || 'N/A'}
+              </p>
+            </div>
+          </SectionCard>
+          <FileListCard header="Files" files={[]} />
+          <FileListCard header="Notes" files={[]} />
+        </div>
+      </div>
     </main>
-);
+  );
+};
 
 export default PatientProfilePage;

--- a/src/pages/DoctorPage/DoctorPatientPage.tsx
+++ b/src/pages/DoctorPage/DoctorPatientPage.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useAuth } from '../../contexts/ContextsAuth';
+import PatientProfilePage, { PatientInfo } from '../../components/Doctor/PatientProfilePage';
+import { getPatientById } from '../../services/patientService';
+
+const DoctorPatientPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const { accessToken } = useAuth();
+  const [patient, setPatient] = useState<PatientInfo | null>(null);
+
+  useEffect(() => {
+    if (!id || !accessToken) return;
+    getPatientById(id, accessToken)
+      .then(setPatient)
+      .catch((err) => console.error('Failed to load patient', err));
+  }, [id, accessToken]);
+
+  return <PatientProfilePage patient={patient} />;
+};
+
+export default DoctorPatientPage;

--- a/src/services/patientService.ts
+++ b/src/services/patientService.ts
@@ -1,0 +1,9 @@
+import api from './api';
+import { API_ENDPOINTS } from '../constants/apiConfig';
+
+export const getPatientById = async (id: number | string, token: string) => {
+  const res = await api.get(API_ENDPOINTS.doctor(id), {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- allow doctor to open patient details from patient table
- add patient fetching service and page
- update patient profile component to display API data
- register route for patient profile in app router

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6860b90357948331aea552072f3286a9