### PR TITLE
Load patient details once

### DIFF
--- a/src/components/Doctor/PatientProfilePage.tsx
+++ b/src/components/Doctor/PatientProfilePage.tsx
@@ -28,6 +28,7 @@ export interface PatientInfo {
   gender: string;
   appointments: AppointmentInfo[];
   imageUrl: string | null;
+  drugs?: DrugInfo[];
 }
 
 export interface DrugInfo {
@@ -42,10 +43,12 @@ interface Props {
   drugs?: DrugInfo[];
 }
 
-const PatientProfilePage: React.FC<Props> = ({ patient, drugs = [] }) => {
+const PatientProfilePage: React.FC<Props> = ({ patient, drugs }) => {
   if (!patient) {
     return <main className="p-6">Loading...</main>;
   }
+
+  const drugList = drugs ?? patient.drugs ?? [];
 
   return (
     <main className="flex-1 p-6 bg-gray-50 overflow-y-auto">
@@ -130,11 +133,11 @@ const PatientProfilePage: React.FC<Props> = ({ patient, drugs = [] }) => {
           <FileListCard header="Files" files={[]} actions={<button className="text-sm px-2 py-1 rounded bg-blue-600 text-white">+ Add File</button>} />
           <FileListCard header="Notes" files={[]} actions={<button className="text-sm px-2 py-1 rounded bg-blue-600 text-white">+ Add Note</button>} />
           <SectionCard title="Drugs" actions={<button className="text-sm px-2 py-1 rounded bg-blue-600 text-white">+ Add Drug</button>}>
-            {drugs.length === 0 ? (
+            {drugList.length === 0 ? (
               <p className="text-sm text-gray-500">No medications found.</p>
             ) : (
               <ul className="text-sm space-y-1">
-                {drugs.map((d) => (
+                {drugList.map((d) => (
                   <li key={d.id} className="flex justify-between">
                     <span>{d.drugName}</span>
                     <span className="text-gray-500">{d.frequency}/day</span>

--- a/src/pages/DoctorPage/DoctorAppointmentPage.tsx
+++ b/src/pages/DoctorPage/DoctorAppointmentPage.tsx
@@ -7,7 +7,6 @@ import { PatientHeader } from '../../components/Doctor/PatientHeader';
 import { SectionCard } from '../../components/Doctor/SectionCard';
 import { useAuth } from '../../contexts/ContextsAuth';
 import { getPatientById } from '../../services/patientService';
-import { getPatientDrugs } from '../../services/drugService';
 import { PatientInfo, DrugInfo, AppointmentInfo } from '../../components/Doctor/PatientProfilePage';
 
 interface LocationState { appointment: AppointmentInfo; }
@@ -17,17 +16,15 @@ const DoctorAppointmentPage: React.FC = () => {
   const appointment = state?.appointment;
   const { user,accessToken } = useAuth();
   const [patient, setPatient] = useState<PatientInfo | null>(null);
-  const [drugs, setDrugs] = useState<DrugInfo[]>([]);
   const [section, setSection] = useState('appointments');
 
   useEffect(() => {
     if (!appointment || !accessToken || !user) return;
-    getPatientById(user.id,appointment.patientId, accessToken)
-      .then(setPatient)
+    getPatientById(user.id, appointment.patientId, accessToken)
+      .then((data) => {
+        setPatient(data);
+      })
       .catch((err) => console.error('Patient fetch error', err));
-    getPatientDrugs(appointment.patientId, accessToken)
-      .then(setDrugs)
-      .catch((err) => console.error('Drug fetch error', err));
   }, [appointment, accessToken]);
 
   return (
@@ -52,17 +49,17 @@ const DoctorAppointmentPage: React.FC = () => {
             <p>Loading...</p>
           )}
           <SectionCard title="Drugs">
-            {drugs.length === 0 ? (
-              <p className="text-sm text-gray-500">No medications found.</p>
-            ) : (
+            {patient?.drugs && patient.drugs.length > 0 ? (
               <ul className="text-sm space-y-1">
-                {drugs.map((d) => (
+                {patient.drugs.map((d) => (
                   <li key={d.id} className="flex justify-between">
                     <span>{d.drugName}</span>
                     <span className="text-gray-500">{d.frequency}/day</span>
                   </li>
                 ))}
               </ul>
+            ) : (
+              <p className="text-sm text-gray-500">No medications found.</p>
             )}
           </SectionCard>
         </main>

--- a/src/pages/DoctorPage/DoctorPatientPage.tsx
+++ b/src/pages/DoctorPage/DoctorPatientPage.tsx
@@ -3,7 +3,6 @@ import { useParams } from 'react-router-dom';
 import { useAuth } from '../../contexts/ContextsAuth';
 import PatientProfilePage, { PatientInfo } from '../../components/Doctor/PatientProfilePage';
 import { getPatientById } from '../../services/patientService';
-import { getPatientDrugs } from '../../services/drugService';
 import DoctorNavbar from '../../components/Doctor/DoctorNavbar';
 import DoctorSidebar from '../../components/Doctor/DoctorSidebar';
 
@@ -11,17 +10,15 @@ const DoctorPatientPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const { user,accessToken } = useAuth();
   const [patient, setPatient] = useState<PatientInfo | null>(null);
-  const [drugs, setDrugs] = useState<any[]>([]);
   const [section, setSection] = useState('patients');
 
   useEffect(() => {
-    if (!id || !accessToken ||!user) return;
-    getPatientById(user.id,id, accessToken)
-      .then(setPatient)
+    if (!id || !accessToken || !user) return;
+    getPatientById(user.id, id, accessToken)
+      .then((data) => {
+        setPatient(data);
+      })
       .catch((err) => console.error('Failed to load patient', err));
-    getPatientDrugs(id, accessToken)
-      .then(setDrugs)
-      .catch((err) => console.error('Failed to load drugs', err));
   }, [id, accessToken]);
 
   return (
@@ -31,7 +28,7 @@ const DoctorPatientPage: React.FC = () => {
       </div>
       <div className="flex flex-1">
         <DoctorSidebar selected={section} onSelect={setSection} />
-        <PatientProfilePage patient={patient} drugs={drugs} />
+        <PatientProfilePage patient={patient} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- enrich `PatientInfo` with optional drug list
- use the drug list from `PatientInfo` in patient profile
- fetch drugs only via `getPatientById` in doctor pages

## Testing
- `npm run lint`
- `npm run build` *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6861a8248ab0833190564aee1eb70602