### PR TITLE
Refactor doctor schedule modal

### DIFF
--- a/src/components/Doctor/DoctorScheduleTable.tsx
+++ b/src/components/Doctor/DoctorScheduleTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import dayjs from 'dayjs';
 import {useTranslation} from "react-i18next";
 
@@ -12,44 +12,19 @@ export interface ScheduleEntry {
 
 interface Props {
     data: ScheduleEntry[];
-    onAddHoliday: (entry: ScheduleEntry) => void;
+    onEdit: (entry: ScheduleEntry) => void;
     onDelete: (id: number) => void;
-    onUpdate: (entry: ScheduleEntry) => void;
 }
 
 const formatTime = (time?: string) => {
     return time ? dayjs(`1970-01-01T${time}`).format('hh:mm A') : '';
 };
 
-const DoctorScheduleTable: React.FC<Props> = ({ data, onAddHoliday, onDelete, onUpdate }) => {
-    const [showModal, setShowModal] = useState(false);
-    const [editEntry, setEditEntry] = useState<ScheduleEntry | null>(null);
-    const [dayOfWeek, setDayOfWeek] = useState('');
-    const [startTime, setStartTime] = useState('');
-    const [endTime, setEndTime] = useState('');
+const DoctorScheduleTable: React.FC<Props> = ({ data, onEdit, onDelete }) => {
     const {t} =useTranslation();
 
-    const handleSubmit = () => {
-        if (!dayOfWeek) return;
-        const entry: ScheduleEntry = { id: editEntry?.id, dayOfWeek, startTime, endTime };
-        if (editEntry) {
-            onUpdate(entry);
-        } else {
-            onAddHoliday(entry);
-        }
-        setShowModal(false);
-        setDayOfWeek('');
-        setStartTime('');
-        setEndTime('');
-        setEditEntry(null);
-    };
-
     const openEdit = (entry: ScheduleEntry) => {
-        setEditEntry(entry);
-        setDayOfWeek(entry.dayOfWeek);
-        setStartTime(entry.startTime ? entry.startTime.slice(0,5) : '');
-        setEndTime(entry.endTime ? entry.endTime.slice(0,5) : '');
-        setShowModal(true);
+        onEdit(entry);
     };
 
     return (
@@ -104,82 +79,6 @@ const DoctorScheduleTable: React.FC<Props> = ({ data, onAddHoliday, onDelete, on
                 </table>
             </div>
 
-            {/* Buttons */}
-            <div className="flex justify-end gap-4">
-                <button className="bg-blue-600 hover:bg-blue-700 text-white px-5 py-2 rounded shadow text-sm"
-                        onClick={() => setShowModal(true)}
-                >
-                    {t("AddSchedule")}
-                </button>
-                <button
-                    className="bg-red-600 hover:bg-red-700 text-white px-5 py-2 rounded shadow text-sm">
-                    {t("AddHoliday")}
-                </button>
-            </div>
-
-            {/* Modal */}
-            {showModal && (
-                <div className="fixed inset-0 flex items-center justify-center z-50 bg-black bg-opacity-30">
-                    <div className="bg-white p-6 rounded-lg shadow-xl w-full max-w-md">
-                        <h2 className="text-lg font-semibold mb-4">
-                            {editEntry ? t('editSchedule') : t('addSchedule')}
-                        </h2>
-
-                        <div className="mb-4">
-                            <label className="block text-sm font-medium mb-1">{t('day')}</label>
-                            <select
-                                value={dayOfWeek}
-                                onChange={(e) => setDayOfWeek(e.target.value)}
-                                className="w-full border px-3 py-2 rounded"
-                            >
-                                <option value="">{t("select")}</option>
-                                {['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'].map(
-                                    (day) => (
-                                        <option key={day} value={day.toUpperCase()}>
-                                            {day}
-                                        </option>
-                                    )
-                                )}
-                            </select>
-                        </div>
-
-                        <div className="mb-4">
-                            <label className="block text-sm font-medium mb-1">{t("startTime")}</label>
-                            <input
-                                type="time"
-                                value={startTime}
-                                onChange={(e) => setStartTime(e.target.value)}
-                                className="w-full border px-3 py-2 rounded"
-                            />
-                        </div>
-
-                        <div className="mb-4">
-                            <label className="block text-sm font-medium mb-1">{t("endTime")}</label>
-                            <input
-                                type="time"
-                                value={endTime}
-                                onChange={(e) => setEndTime(e.target.value)}
-                                className="w-full border px-3 py-2 rounded"
-                            />
-                        </div>
-
-                        <div className="flex justify-end gap-2">
-                            <button
-                                onClick={() => setShowModal(false)}
-                                className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
-                            >
-                                {t("cancel")}
-                            </button>
-                            <button
-                                onClick={handleSubmit}
-                                className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
-                            >
-                                {editEntry ? t('update') : t('add')}
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            )}
         </div>
     );
 };

--- a/src/components/Doctor/ScheduleModal.tsx
+++ b/src/components/Doctor/ScheduleModal.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ScheduleEntry } from './DoctorScheduleTable';
+
+interface Props {
+  initialEntry?: ScheduleEntry | null;
+  onSubmit: (entry: ScheduleEntry) => void;
+  onClose: () => void;
+}
+
+const weekdays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+const ScheduleModal: React.FC<Props> = ({ initialEntry, onSubmit, onClose }) => {
+  const { t } = useTranslation();
+  const [dayOfWeek, setDayOfWeek] = useState('');
+  const [startTime, setStartTime] = useState('');
+  const [endTime, setEndTime] = useState('');
+
+  useEffect(() => {
+    if (initialEntry) {
+      setDayOfWeek(initialEntry.dayOfWeek);
+      setStartTime(initialEntry.startTime ? initialEntry.startTime.slice(0, 5) : '');
+      setEndTime(initialEntry.endTime ? initialEntry.endTime.slice(0, 5) : '');
+    } else {
+      setDayOfWeek('');
+      setStartTime('');
+      setEndTime('');
+    }
+  }, [initialEntry]);
+
+  const handleSubmit = () => {
+    if (!dayOfWeek) return;
+    const entry: ScheduleEntry = {
+      id: initialEntry?.id,
+      dayOfWeek,
+      startTime,
+      endTime,
+      isHoliday: initialEntry?.isHoliday,
+    };
+    onSubmit(entry);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center z-50 bg-black bg-opacity-30">
+      <div className="bg-white p-6 rounded-lg shadow-xl w-full max-w-md">
+        <h2 className="text-lg font-semibold mb-4">
+          {initialEntry ? t('editSchedule') : t('addSchedule')}
+        </h2>
+        <div className="mb-4">
+          <label className="block text-sm font-medium mb-1">{t('day')}</label>
+          <select
+            value={dayOfWeek}
+            onChange={(e) => setDayOfWeek(e.target.value)}
+            className="w-full border px-3 py-2 rounded"
+          >
+            <option value="">{t('select')}</option>
+            {weekdays.map((day) => (
+              <option key={day} value={day.toUpperCase()}>
+                {day}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="mb-4">
+          <label className="block text-sm font-medium mb-1">{t('startTime')}</label>
+          <input
+            type="time"
+            value={startTime}
+            onChange={(e) => setStartTime(e.target.value)}
+            className="w-full border px-3 py-2 rounded"
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block text-sm font-medium mb-1">{t('endTime')}</label>
+          <input
+            type="time"
+            value={endTime}
+            onChange={(e) => setEndTime(e.target.value)}
+            className="w-full border px-3 py-2 rounded"
+          />
+        </div>
+        <div className="flex justify-end gap-2">
+          <button onClick={onClose} className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">
+            {t('cancel')}
+          </button>
+          <button onClick={handleSubmit} className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700">
+            {initialEntry ? t('update') : t('add')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ScheduleModal;


### PR DESCRIPTION
## Summary
- move schedule form into new `ScheduleModal` component
- simplify `DoctorScheduleTable` to just display schedules
- use new modal in doctor dashboard and wire up add/edit actions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6861b4c9a06c8331b8d8c3f366ed2835