### PR TITLE
Fix service modal and add price field

### DIFF
--- a/src/components/Doctor/DoctorServicesTable.tsx
+++ b/src/components/Doctor/DoctorServicesTable.tsx
@@ -5,6 +5,7 @@ export interface ServiceEntry {
   doctorId: number;
   id: number;
   service: string;
+  price: number;
 }
 
 interface Props {
@@ -23,6 +24,7 @@ const DoctorServicesTable: React.FC<Props> = ({ data, onEdit, onDelete }) => {
           <tr className="ltr:text-left rtl:text-right">
             <th className="px-6 py-3">#</th>
             <th className="px-6 py-3">{t('service')}</th>
+            <th className="px-6 py-3">{t('price')}</th>
             <th className="px-6 py-3">{t('actions')}</th>
           </tr>
         </thead>
@@ -31,6 +33,7 @@ const DoctorServicesTable: React.FC<Props> = ({ data, onEdit, onDelete }) => {
             <tr key={entry.id} className="hover:bg-tableHover ltr:text-left rtl:text-right">
               <td className="px-6 py-4 font-medium">{idx + 1}</td>
               <td className="px-6 py-4 ">{entry.service}</td>
+              <td className="px-6 py-4 ">{entry.price}</td>
               <td className="px-6 py-4 flex gap-2 rtl:space-x-reverse">
                 <button onClick={() => onEdit(entry)} className="text-blue-600 hover:underline">
                   {t('edit')}

--- a/src/components/Doctor/ServiceModal.tsx
+++ b/src/components/Doctor/ServiceModal.tsx
@@ -12,10 +12,12 @@ interface Props {
 const ServiceModal: React.FC<Props> = ({ options, initialEntry, onSubmit, onClose }) => {
   const { t } = useTranslation();
   const [service, setService] = useState('');
+  const [price, setPrice] = useState(0);
 
   useEffect(() => {
     if (initialEntry) {
-      setService(initialEntry.services);
+      setService(initialEntry.service);
+      setPrice(initialEntry.price);
     } else if (options.length > 0) {
       setService(options[0]);
     }
@@ -26,7 +28,8 @@ const ServiceModal: React.FC<Props> = ({ options, initialEntry, onSubmit, onClos
     const entry: ServiceEntry = {
       doctorId: initialEntry?.doctorId ?? 0,
       id: initialEntry?.id ?? 0,
-      services: service,
+      service,
+      price,
     };
     onSubmit(entry);
     onClose();
@@ -51,6 +54,15 @@ const ServiceModal: React.FC<Props> = ({ options, initialEntry, onSubmit, onClos
               </option>
             ))}
           </select>
+        </div>
+        <div className="mb-4">
+          <label className="block text-sm font-medium mb-1">{t('price')}</label>
+          <input
+            type="number"
+            value={price}
+            onChange={(e) => setPrice(parseFloat(e.target.value))}
+            className="w-full border px-3 py-2 rounded"
+          />
         </div>
         <div className="flex justify-end gap-2">
           <button onClick={onClose} className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -148,6 +148,7 @@
   "servicesTab": "الخدمات",
   "addService": "اضافة خدمة",
   "editService": "تعديل الخدمة",
-  "service": "الخدمة"
+  "service": "الخدمة",
+  "price": "السعر"
 
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -150,7 +150,8 @@
   "servicesTab": "Services",
   "addService": "Add Service",
   "editService": "Edit Service",
-  "service": "Service"
+  "service": "Service",
+  "price": "Price"
 
 
 

--- a/src/pages/DoctorPage/DoctorHomePage.tsx
+++ b/src/pages/DoctorPage/DoctorHomePage.tsx
@@ -109,10 +109,10 @@ const DoctorDashboard: React.FC = () => {
 
     useEffect(() => {
         if (!user ) return;
-        getServiceOptions(accessToken)
+        getServiceOptions(accessToken ?? undefined)
             .then(setServiceOptions)
             .catch((err) => console.error('Service options fetch error:', err));
-        getDoctorServices(user.id, accessToken)
+        getDoctorServices(user.id, accessToken ?? undefined)
             .then(setServicesList)
             .catch((err) => console.error('Doctor services fetch error:', err));
     }, [user, accessToken]);
@@ -216,7 +216,7 @@ const DoctorDashboard: React.FC = () => {
         if (editService && editService.id) {
             try {
                 await updateDoctorService(user.id, { ...entry, id: editService.id, doctorId: user.id }, accessToken);
-                setServicesList((prev) => prev.map((s) => (s.id === editService.id ? { ...s, services: entry.service } : s)));
+                setServicesList((prev) => prev.map((s) => (s.id === editService.id ? { ...s, service: entry.service, price: entry.price } : s)));
             } catch (err) {
                 console.error('❌ Failed to update service:', err);
             }

--- a/src/services/doctorService.ts
+++ b/src/services/doctorService.ts
@@ -96,6 +96,7 @@ export interface DoctorServiceEntry {
   doctorId: number;
   id: number;
   service: string;
+  price: number;
 }
 
 export const getServiceOptions = async (token?: string) => {


### PR DESCRIPTION
## Summary
- avoid passing null accessToken to service functions
- show service price in doctor services table
- allow editing service price in ServiceModal
- update translations for price label
- include price in doctor service payload interface

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e9a7ff00c83319849e764e2382de5